### PR TITLE
implementing memoized redux state and some home data layer refactoring

### DIFF
--- a/client/src/screens/Home/data/homeImageMaps.js
+++ b/client/src/screens/Home/data/homeImageMaps.js
@@ -1,0 +1,18 @@
+export const filterImageMap = {
+  'Two Michelin stars': 'https://source.unsplash.com/Z6E62SLyqj8',
+  'Peaceful location': 'https://source.unsplash.com/Uq3gTiPlqRo',
+  'Locally brewed beer': 'https://source.unsplash.com/EHbtjmz7hvw',
+  'View of London': 'https://source.unsplash.com/DpI-_wydgJM',
+  'Red seats': 'https://source.unsplash.com/8aYbhJOhtJw',
+  'Specialty coffee': 'https://source.unsplash.com/lcfH0p6emhw',
+  'Vegan friendly': 'https://source.unsplash.com/2IxTgsgFi-s',
+  'Accessible': 'https://source.unsplash.com/ju1yFZkrxVg',
+  'Helal beer': 'https://source.unsplash.com/C8eSYwQkwHw'
+}
+
+export const cityImageMap = {
+  'Seattle': 'https://source.unsplash.com/QEob0Fp4rdg',
+  'Tokyo': 'https://source.unsplash.com/IocJwyqRv3M',
+  'New York' : 'https://source.unsplash.com/wpU4veNGnHg',
+  'London': 'https://source.unsplash.com/fk50kc-DzSg'
+}

--- a/client/src/screens/Home/data/homeSelectors.js
+++ b/client/src/screens/Home/data/homeSelectors.js
@@ -1,0 +1,52 @@
+import { createSelector } from 'reselect'
+
+// Derived Cities data
+export const getCities = (state) => state.home.cities
+export const getCitiesImages = (state) => state.home.citiesImages
+export const getCitiesRequest = (state) => state.home.citiesRequest
+export const getSelectedCity = (state) => state.home.selectedCity
+
+export const getCitiesData = createSelector(
+  getCities,
+  getCitiesImages,
+  getCitiesRequest,
+  getSelectedCity,
+  (cities, citiesImages, citiesRequest, selectedCity) => ({
+    cities,
+    citiesImages,
+    citiesRequest,
+    selectedCity
+  })
+)
+
+// Derived Filters data
+export const getFilters = (state) => state.home.filters
+export const getFiltersImages = (state) => state.home.filtersImages
+export const getFiltersRequest = (state) => state.home.filtersRequest
+export const getSelectedFilters = (state) => state.home.selectedFilters
+
+export const getFiltersData = createSelector(
+  getFilters,
+  getFiltersImages,
+  getFiltersRequest,
+  getSelectedFilters,
+  (filters, filtersImages, filtersRequest, selectedFilters) => ({
+    filters,
+    filtersImages,
+    filtersRequest,
+    selectedFilters
+  })
+)
+
+// Derived Places data
+export const getPlaces = (state) => state.home.places
+export const getPlacesRequest = (state) => state.home.placesRequest
+
+export const getPlacesData = createSelector(
+  getPlaces,
+  getPlacesRequest,
+  (places, placesRequest) => ({
+    places,
+    placesRequest
+  })
+)

--- a/client/src/screens/Home/data/homeSlice.js
+++ b/client/src/screens/Home/data/homeSlice.js
@@ -2,11 +2,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
 import http from 'modules/http'
 
-const filtersStub = [
-  'Vegan',
-  'Locally sourced',
-  'Farm'
-]
+import { cityImageMap, filterImageMap } from 'screens/Home/data/homeImageMaps'
 
 export const requestGetCities = createAsyncThunk(
   'home/reqGetCities',
@@ -28,10 +24,12 @@ export const homeSlice = createSlice({
 
   initialState: {
     cities: [],
+    citiesImages: cityImageMap,
     citiesRequest: 'initial',
     selectedCity: null,
 
-    filters: filtersStub,
+    filters: [],
+    filtersImages: filterImageMap,
     filtersRequest: 'initial',
     selectedFilters: [],
 

--- a/client/src/screens/Home/ui/CitySelect.js
+++ b/client/src/screens/Home/ui/CitySelect.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
 import { setSelectedCity, requestGetPlaces, requestGetCities, resetRequestStatus } from 'screens/Home/data/homeSlice'
+import { getCitiesData } from 'screens/Home/data/homeSelectors'
 
 import Card from 'components/Card/Card'
 import Modal from 'components/Modal/Modal'
@@ -12,46 +13,37 @@ const initialState = {
   selectedCityImage: null
 }
 
-const cityImageMap = {
-  'Seattle': 'https://source.unsplash.com/QEob0Fp4rdg',
-  'Tokyo': 'https://source.unsplash.com/IocJwyqRv3M',
-  'New York' : 'https://source.unsplash.com/wpU4veNGnHg',
-  'London': 'https://source.unsplash.com/fk50kc-DzSg'
-}
-
 function CitySelect () {
   const dispatch = useDispatch()
 
-  const cities = useSelector((state) => state.home.cities)
-  const citiesRequest = useSelector((state) => state.home.citiesRequest)
-  const selectedCity = useSelector((state) => state.home.selectedCity)
-  
+  const citiesData = useSelector(getCitiesData)
+
   const [isSelecting, setIsSelecting] = useState(initialState.isSelecting)
   const [selectedCityImage, setSelectedCityImage] = useState(initialState.selectedCityImage)
 
   useEffect(() => {
-    if (citiesRequest === 'initial') {
+    if (citiesData.citiesRequest === 'initial') {
       dispatch(requestGetCities())
     }
 
-    if (selectedCity) {
-      dispatch(requestGetPlaces(selectedCity.id))
+    if (citiesData.selectedCity) {
+      dispatch(requestGetPlaces(citiesData.selectedCity.id))
       dispatch(resetRequestStatus('filtersRequest'))
-      setSelectedCityImage(cityImageMap[selectedCity.name])
+      setSelectedCityImage(citiesData.citiesImages[citiesData.selectedCity.name])
     }
-  }, [dispatch, selectedCity, citiesRequest])
+  }, [dispatch, citiesData.selectedCity, citiesData.citiesImages, citiesData.citiesRequest])
   
   const handleCitySelection = (id) =>{
     dispatch(setSelectedCity(id))
     setIsSelecting(false)
   }
 
-  const generateCityChoiceModalContent = () => cities.map((city) => (
+  const generateCityChoiceModalContent = () => citiesData.cities.map((city) => (
     <div className="block" key={`city-select-block-${city.id}`}>
       <Card
         cardType="image"
         clickHandler={ () => handleCitySelection(city.id) }
-        image={ cityImageMap[city.name] }
+        image={ citiesData.citiesImages[city.name] }
         imageRatio="is-2by1"
         title={ city.name }
       />
@@ -60,7 +52,7 @@ function CitySelect () {
 
   return (
     <>
-      { citiesRequest === 'completed'
+      { citiesData.citiesRequest === 'completed'
         ? (
           <div className="block">
             <h3 className="title is-4">Find places in</h3>
@@ -69,7 +61,7 @@ function CitySelect () {
               imageRatio="is-16by9"
               image={ selectedCityImage }
               clickHandler={ () => setIsSelecting(true) }
-              title={ selectedCity.name }
+              title={ citiesData.selectedCity.name }
             />
       
             <Modal 

--- a/client/src/screens/Home/ui/FilterSelect.js
+++ b/client/src/screens/Home/ui/FilterSelect.js
@@ -2,35 +2,23 @@ import React, { useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
 import { requestGetFilters, setSelectedFilter } from 'screens/Home/data/homeSlice'
+import { getFiltersData, getCitiesData } from 'screens/Home/data/homeSelectors'
 
 import Card from 'components/Card/Card'
 import Notification from 'components/Notification/Notification'
 
-const filterImageMap = {
-  'Two Michelin stars': 'https://source.unsplash.com/Z6E62SLyqj8',
-  'Peaceful location': 'https://source.unsplash.com/Uq3gTiPlqRo',
-  'Locally brewed beer': 'https://source.unsplash.com/EHbtjmz7hvw',
-  'View of London': 'https://source.unsplash.com/DpI-_wydgJM',
-  'Red seats': 'https://source.unsplash.com/8aYbhJOhtJw',
-  'Specialty coffee': 'https://source.unsplash.com/lcfH0p6emhw',
-  'Vegan friendly': 'https://source.unsplash.com/2IxTgsgFi-s',
-  'Accessible': 'https://source.unsplash.com/ju1yFZkrxVg',
-  'Helal beer': 'https://source.unsplash.com/C8eSYwQkwHw'
-}
-
 function FilterSelect () {
   const dispatch = useDispatch()
 
-  const citiesRequest = useSelector((state) => state.home.citiesRequest)
-  const selectedCity = useSelector((state) => state.home.selectedCity)
-
-  const filters = useSelector((state) => state.home.filters)
-  const filtersRequest = useSelector((state) => state.home.filtersRequest)
-  const selectedFilters = useSelector((state) => state.home.selectedFilters)
+  const filtersData = useSelector(getFiltersData);
+  const citiesData = useSelector(getCitiesData)
 
   useEffect(() => {
-    if (citiesRequest === 'completed' && filtersRequest === 'initial') {
-      dispatch(requestGetFilters(selectedCity.id))
+    if (
+      citiesData.citiesRequest === 'completed' 
+      && filtersData.filtersRequest === 'initial'
+    ) {
+      dispatch(requestGetFilters(citiesData.selectedCity.id))
     }
   })
 
@@ -40,7 +28,10 @@ function FilterSelect () {
 
   const generateFilterSelector = () => {
     const filterSelector = []
-    const aggregatedFilters = filters.usps.concat(filters.vital_infos)
+    const aggregatedFilters = 
+      filtersData.filters.usps.concat(
+        filtersData.filters.vital_infos
+      )
 
     if (aggregatedFilters.length) {
 
@@ -48,14 +39,14 @@ function FilterSelect () {
 
         aggregatedFilters.map((filter => {
 
-          let isSelected = selectedFilters.includes(filter.id)
+          let isSelected = filtersData.selectedFilters.includes(filter.id)
 
           return (
             <div className="column" key={`filter-select-block-${filter.id}`}>
               <Card
                 cardType='image'
                 imageRatio='is-128x128'
-                image={ filterImageMap[filter.usp || filter.vital_info] }
+                image={ filtersData.filtersImages[filter.usp || filter.vital_info] }
                 title={ filter.usp || filter.vital_info }
                 isSelected={ isSelected }
                 clickHandler={() => handleFilterSelection(filter.id)}
@@ -71,7 +62,8 @@ function FilterSelect () {
 
   return (
     <>
-      { filtersRequest === 'completed' && (filters.usps || filters.vital_infos)
+      { filtersData.filtersRequest === 'completed' 
+        && (filtersData.filters.usps || filtersData.filters.vital_infos)
         ? (
           <div className="block">
             <h3 className="title is-4">Filters</h3>
@@ -82,7 +74,7 @@ function FilterSelect () {
         ) : (
           <Notification 
             message={
-              filtersRequest === 'completed'
+              filtersData.filtersRequest === 'completed'
               ? 'No filters found'
               : 'Loading filters...'
             }

--- a/client/src/screens/Home/ui/PlaceSelect.js
+++ b/client/src/screens/Home/ui/PlaceSelect.js
@@ -1,17 +1,18 @@
 import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
+import { getPlacesData, getSelectedFilters } from 'screens/Home/data/homeSelectors'
+
 import Notification from 'components/Notification/Notification'
 import Card from 'components/Card/Card'
 
 function PlaceSelect () {
-  let places = useSelector((state) => state.home.places)
-  const placesRequest = useSelector((state) => state.home.placesRequest)
-  const selectedFilters = useSelector((state) => state.home.selectedFilters)
+  const placesData = useSelector(getPlacesData)
+  const selectedFilters = useSelector(getSelectedFilters)
 
   const testImage = 'https://source.unsplash.com/GXXYkSwndP4/1600x900'
 
-  const generatePlacesChoiceContent = () => {
+  const generatePlacesChoiceContent = (places) => {
     if (!places.length) {
       return (
         <Notification 
@@ -32,6 +33,7 @@ function PlaceSelect () {
 
     return places.map((place) => (
       <Card
+        key={`place-select-card-${ place.name }`}
         cardType="image"
         image={ testImage }
         imageRatio="is-2by1"
@@ -43,9 +45,9 @@ function PlaceSelect () {
   return (
     <div className="block">
       <h3 className="title is-4">Places</h3>
-      { placesRequest === 'completed'
+      { placesData.placesRequest === 'completed'
         ? (
-            generatePlacesChoiceContent() 
+            generatePlacesChoiceContent(placesData.places) 
         )
         : (
             <Notification 


### PR DESCRIPTION
I wanted to clean up the approach a bit before we dive into the next screen.

## Summary

- Implemented memoized Redux state by way of `reselect`'s `createSelector` function. This should greatly reduce the number of times the data layer is calculated
- Adding the `homeSelectors` file to encapsulate the above, and create a standard protocol for retrieving Redux data (derived or raw).
- Moved the image maps to their own file: `homeImageMaps.js`
- Refactored the UI components to use this derived data (`CitySelect`, `FilterSelect`, `PlaceSelect`), as a byproduct we get:

  - Name-spaced data, so it's clear in the UI code where each piece of state data originated
  - Reduced the overall amount of code in the UI files