### PR TITLE
adding place data to place screen

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>The Curation</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/containers/Place/Place.js
+++ b/client/src/containers/Place/Place.js
@@ -3,25 +3,51 @@ import { useSelector, useDispatch } from 'react-redux'
 
 import { setCurrentScreen, setSelectedPlaceId } from 'containers/App/data/appSlice'
 import { getAppData } from 'containers/App/data/appSelectors'
+import { requestGetPlace, resetPlaceRequest } from 'containers/Place/data/placeSlice'
+import { getPlaceData } from 'containers/Place/data/placeSelectors'
+
+import Notification from 'components/Notification/Notification'
 
 const Place = () => {
   const dispatch = useDispatch()
   const appData = useSelector(getAppData)
+  const placeData = useSelector(getPlaceData)
 
-  useEffect(() => {})
+  useEffect(() => {
+    if (placeData.placeRequest === 'initial') {
+      dispatch(
+        requestGetPlace(appData.selectedPlaceId)
+      )
+    }
+  })
 
   const handleHomeClick = () => {
     dispatch(setCurrentScreen('Home'))
     dispatch(setSelectedPlaceId(null))
+    dispatch(resetPlaceRequest())
   }
 
   return (
     <>
-      <button className="button" onClick={ () => handleHomeClick() }>
-        Home
-      </button>
-      <h1>Place screen!!!</h1>
-      <p>Selected place Id: {appData.selectedPlaceId}</p>
+      { placeData.placeRequest === 'completed'
+      ? (
+        <div>
+          <button className="button" onClick={ () => handleHomeClick() }>
+            Home
+          </button>
+
+          <p>Name: { placeData.place.name }</p>
+          <p>Type: { placeData.place.place_type }</p>
+          <p>Website: { placeData.place.website }</p>
+          <p>Address: {placeData.place.address }</p>
+          <p>Email: { placeData.place.email_address }</p>
+          <p>Copy: {placeData.place.copy }</p>
+        </div>
+      ): (
+        <Notification 
+          message="Loading place data"
+        />
+      )}
     </>
   )
 }

--- a/client/src/containers/Place/data/placeSelectors.js
+++ b/client/src/containers/Place/data/placeSelectors.js
@@ -1,0 +1,16 @@
+import { createSelector } from 'reselect' 
+
+export const getPlace = (state) => state.place.place
+export const getPlaceId = (state) => state.place.placeId
+export const getPlaceRequest = (state) => state.place.placeRequest
+
+export const getPlaceData = createSelector(
+  getPlace,
+  getPlaceId,
+  getPlaceRequest,
+  (place, placeId, placeRequest) => ({
+    place,
+    placeId,
+    placeRequest
+  })
+)

--- a/client/src/containers/Place/data/placeSlice.js
+++ b/client/src/containers/Place/data/placeSlice.js
@@ -1,0 +1,43 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+
+import http from 'modules/http'
+
+export const requestGetPlace = createAsyncThunk(
+  'place/reqPlace',
+  async (placeId) => await http.get('places', placeId, true)
+)
+
+export const placeSlice = createSlice({
+  name: 'place',
+
+  initialState: {
+    placeId: null,
+    place: null,
+    placeRequest: 'initial'
+  },
+
+  reducers: {
+    resetPlaceRequest: (state) => {
+      state.placeRequest = 'initial'
+    }
+  },
+
+  extraReducers: {
+    [requestGetPlace.pending]: (state) => {
+      state.placeRequest = 'pending'
+    },
+
+    [requestGetPlace.fulfilled]: (state, action) => {
+      state.placeRequest = 'completed'
+      state.place = action.payload 
+    },
+
+    [requestGetPlace.rejected]: (state) => {
+      state.placeRequest = 'failed'
+    }
+  }
+})
+
+export const { resetPlaceRequest } = placeSlice.actions
+
+export default placeSlice.reducer

--- a/client/src/modules/http.js
+++ b/client/src/modules/http.js
@@ -1,10 +1,10 @@
 // TODO: make this configurable as an env var or similar
 const baseUrl = 'http://0.0.0.0:8000'
 
-const get = async (endpoint, args) => {
+const get = async (endpoint, args, appendSlash) => {
 
   const url = 
-    `${baseUrl}/${endpoint}/${args ? (args) : ''}`
+    `${baseUrl}/${endpoint}/${args ? (args) : ''}${appendSlash? '/' : ''}`
 
   return fetch(url)
     .then(response => response.json())

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -2,10 +2,12 @@ import { configureStore } from '@reduxjs/toolkit'
 
 import appReducer from 'containers/App/data/appSlice'
 import homeReducer from 'containers/Home/data/homeSlice'
+import placeReducer from 'containers/Place/data/placeSlice'
 
 export default configureStore({
   reducer: {
     app: appReducer,
-    home: homeReducer
+    home: homeReducer,
+    place: placeReducer
   },
 })


### PR DESCRIPTION
This PR renders all data from the `/places/{place-id}/` endpoint for the selected place. 

It's the first step to displaying real data on the `Place` screen. The second step will be to use @Kayra's new endpoints to retrieve USPs, Vital Infos, and Opening Hours after the initial request. I was pretty high when I wrote this, so LMK if something doesn't make sense.

## Summary
- `Place` screen now dispatches HTTP request for `/places/{place-id}/`
- Added `Place` data layer (`placeSlice.js` and `placeSelectors.js`)
- Added additional param bool for trailing slash to the `http` module's `get` function

## Testing
Should be simple:
- Pull down branch
- Click on any Place from the Home screen
- You should be taken to a screen that displays a 'Home' button and a block of data
- All of the data you see will have come from the server

## Screenshot
![image](https://user-images.githubusercontent.com/3612297/121815541-d9858b80-cc2b-11eb-8c81-1458a51cd5de.png)
