### PR TITLE
adding PlaceTypeSelect functionality and a bit of refactoring

### DIFF
--- a/client/src/containers/Home/Home.js
+++ b/client/src/containers/Home/Home.js
@@ -1,16 +1,18 @@
 import React from 'react'
 
 import CitySelect from 'containers/Home/ui/CitySelect'
+import PlaceTypeSelect from './ui/PlaceTypeSelect'
 import FilterSelect from 'containers/Home/ui/FilterSelect'
-import LocationSelect from 'containers/Home/ui/PlaceSelect'
+import PlaceSelect from 'containers/Home/ui/PlaceSelect'
 
 function Home () {
   return (
     <section className="section">
       <div className="container">
         <CitySelect />
+        <PlaceTypeSelect />
         <FilterSelect />
-        <LocationSelect />
+        <PlaceSelect />
       </div>
     </section>
   )

--- a/client/src/containers/Home/data/homeImageMaps.js
+++ b/client/src/containers/Home/data/homeImageMaps.js
@@ -16,3 +16,10 @@ export const cityImageMap = {
   'New York' : 'https://source.unsplash.com/wpU4veNGnHg',
   'London': 'https://source.unsplash.com/fk50kc-DzSg'
 }
+
+export const placeTypeImageMap = {
+  'Any': 'https://source.unsplash.com/Ly1DHTvjSvs',
+  'Restaurant': 'https://source.unsplash.com/Ciqxn7FE4vE',
+  'Bar': 'https://source.unsplash.com/6UIonphZA5o',
+  'Cafe': 'https://source.unsplash.com/tKN1WXrzQ3s'
+}

--- a/client/src/containers/Home/data/homeSelectors.js
+++ b/client/src/containers/Home/data/homeSelectors.js
@@ -50,3 +50,7 @@ export const getPlacesData = createSelector(
     placesRequest
   })
 )
+
+// Derived Place Type data
+export const getPlaceTypeImages = (state) => state.home.placeTypeImageMap
+export const getSelectedPlaceType = (state) => state.home.selectedPlaceType

--- a/client/src/containers/Home/data/homeSlice.js
+++ b/client/src/containers/Home/data/homeSlice.js
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
 import http from 'modules/http'
 
-import { cityImageMap, filterImageMap } from 'containers/Home/data/homeImageMaps'
+import { cityImageMap, filterImageMap, placeTypeImageMap } from 'containers/Home/data/homeImageMaps'
 
 export const requestGetCities = createAsyncThunk(
   'home/reqGetCities',
@@ -35,6 +35,9 @@ export const homeSlice = createSlice({
 
     places: [],
     placesRequest: 'initial',
+
+    placeTypeImageMap: placeTypeImageMap,
+    selectedPlaceType: 'Any'
   },
 
   reducers: {
@@ -58,6 +61,10 @@ export const homeSlice = createSlice({
         state.selectedFilters = 
           state.selectedFilters.filter((filter) => filter !== action.payload)
       }
+    },
+    
+    setSelectedPlaceType: (state, action) => {
+      state.selectedPlaceType = action.payload
     }
   },
 
@@ -111,7 +118,8 @@ export const {
   resetFilters,
   resetRequestStatus,
   setSelectedCity,
-  setSelectedFilter
+  setSelectedFilter,
+  setSelectedPlaceType
 } = homeSlice.actions
 
 export default homeSlice.reducer

--- a/client/src/containers/Home/ui/CitySelect.js
+++ b/client/src/containers/Home/ui/CitySelect.js
@@ -27,14 +27,16 @@ function CitySelect () {
     if (citiesData.citiesRequest === 'initial') {
       dispatch(requestGetCities())
     }
+  }, [dispatch, citiesData.citiesRequest])
 
+  useEffect(() => {
     if (citiesData.selectedCity) {
       dispatch(requestGetPlaces(citiesData.selectedCity.id))
       dispatch(resetRequestStatus('filtersRequest'))
       dispatch(resetFilters())
       setSelectedCityImage(citiesData.citiesImages[citiesData.selectedCity.name])
     }
-  }, [dispatch, citiesData.selectedCity, citiesData.citiesImages, citiesData.citiesRequest])
+  }, [dispatch, citiesData])
   
   const handleCitySelection = (id) =>{
     dispatch(setSelectedCity(id))

--- a/client/src/containers/Home/ui/PlaceSelect.js
+++ b/client/src/containers/Home/ui/PlaceSelect.js
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
 import { setCurrentScreen, setSelectedPlaceId } from 'containers/App/data/appSlice'
-import { getPlacesData, getSelectedFilters } from 'containers/Home/data/homeSelectors'
+import { getPlacesData, getSelectedFilters, getSelectedPlaceType } from 'containers/Home/data/homeSelectors'
 
 import Notification from 'components/Notification/Notification'
 import Card from 'components/Card/Card'
@@ -12,8 +12,30 @@ function PlaceSelect () {
 
   const placesData = useSelector(getPlacesData)
   const selectedFilters = useSelector(getSelectedFilters)
+  const selectedPlaceType = useSelector(getSelectedPlaceType)
+
+  const [placesToShow, setPlacesToShow] = useState(placesData.places)
 
   const testImage = 'https://source.unsplash.com/GXXYkSwndP4/1600x900'
+
+  useEffect(() => {
+    setPlacesToShow(placesData.places)
+  }, [placesData.places])
+
+  useEffect(() => {
+    const filteredPlaces = placesData.places.filter(place => {
+      const properties = place.usps.concat(place.vital_infos)
+
+      if (selectedPlaceType === 'Any') {
+        return selectedFilters.every((filter) => properties.includes(filter))
+      } else {
+        return selectedFilters.every((filter) => properties.includes(filter)) && place.place_type === selectedPlaceType
+      }
+    })
+
+    setPlacesToShow(filteredPlaces)
+
+  }, [selectedFilters, selectedPlaceType, placesData.places])
 
   const handlePlaceSelect = (placeId) => {
     dispatch(setCurrentScreen('Place'))
@@ -28,15 +50,6 @@ function PlaceSelect () {
           color="is-info"
         />
       )
-    }
-
-    if (selectedFilters.length) {      
-      const filteredPlaces = places.filter(place => {
-        const properties = place.usps.concat(place.vital_infos)
-
-        return selectedFilters.every((filter) => properties.includes(filter))
-      })
-      places = filteredPlaces
     }
 
     return places.map((place) => (
@@ -56,7 +69,7 @@ function PlaceSelect () {
       <h3 className="title is-4">Places</h3>
       { placesData.placesRequest === 'completed'
         ? (
-            generatePlacesChoiceContent(placesData.places) 
+            generatePlacesChoiceContent(placesToShow) 
         )
         : (
             <Notification 

--- a/client/src/containers/Home/ui/PlaceTypeSelect.js
+++ b/client/src/containers/Home/ui/PlaceTypeSelect.js
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+
+import { getPlacesData, getSelectedPlaceType, getPlaceTypeImages } from 'containers/Home/data/homeSelectors'
+
+import { setSelectedPlaceType } from 'containers/Home/data/homeSlice'
+
+import Button from 'components/Button/Button'
+import Card from 'components/Card/Card'
+import Modal from 'components/Modal/Modal'
+import Notification from 'components/Notification/Notification'
+
+const initialState = {
+  isSelecting: false,
+  placeTypes: ['Any']
+}
+
+const PlaceTypeSelect = () => {
+  const dispatch = useDispatch()
+
+  const [isSelecting, setIsSelecting] = useState(initialState.isSelecting)
+  const [placeTypes, setPlaceTypes] = useState(initialState.placeTypes)
+
+  const placesData = useSelector(getPlacesData)
+  const selectedPlaceType = useSelector(getSelectedPlaceType)
+  const placeTypeImages = useSelector(getPlaceTypeImages)
+
+  useEffect(() => {
+    if (placesData.placesRequest === 'completed') {
+      const types = placesData.places.map((place) => place.place_type)
+      setPlaceTypes([...initialState.placeTypes, ...types])
+    }
+  }, [placesData])
+
+  const handlePlaceTypeSelection = (type) =>{
+    dispatch(setSelectedPlaceType(type))
+    setIsSelecting(false)
+  }
+
+  const generatePlaceTypeModalContent = () => placeTypes.map((type) => (
+    <div className="block" key={`type-select-block-${type}`}>
+      <Card
+        cardType="image"
+        clickHandler={ () => handlePlaceTypeSelection(type) }
+        image={ placeTypeImages[type] }
+        imageRatio="is-2by1"
+        title={ type }
+      />
+    </div>
+  ))
+
+  return (
+    <>
+      { placesData.placesRequest === 'completed'
+        ? (
+          <div className="block">
+            <div className="level is-mobile">
+              <div className="level-left">
+                <div className="level-item">
+                  <h3 className="title is-4">Type of place</h3>
+                </div>
+
+                <div className="level-item">
+                  <Button
+                    clickHandler={() => setIsSelecting(true)}
+                    icon='fa-angle-down'
+                    text={ selectedPlaceType }
+                  />
+                </div>
+              </div>
+            </div>
+    
+            <Modal 
+              isActive={ isSelecting }
+              content={ generatePlaceTypeModalContent() }
+              closeHandler={ () => setIsSelecting(false) }
+            />
+          </div>
+        ) : (
+          <Notification 
+            message="Loading types of places..."
+          />
+        )
+      }
+    </>
+  )
+}
+
+export default PlaceTypeSelect


### PR DESCRIPTION
Closes #24 

Added PlaceTypeSelect component that allows the user to pick a Place Type, and have the Place results filtered based on that type

## Summary
- Added PlaceTypeSelect.js component to Home container
- Modified the Place filtering algorithm in PlaceSelect.js to handle additional filtering by type
- Moved the Place filtering algorithm in PlaceSelect.js to a useEffect hook for code-quality and performance improvements
- Added placeTypeImageMap so the Place Type list looks purdy

## To test
- Pull down `place-type-select`
- Run `npm start`
- Click on the button next to the text that reads 'Type of place'
- Select a Place from the resulting screen
- Confirm that results are filtered both by the Type of Place filter and the regular filters (they should both work together, or separately)

## Screenshot
![image](https://user-images.githubusercontent.com/3612297/123183245-0749ac00-d446-11eb-8f8f-9c6b4fdefa36.png)

![image](https://user-images.githubusercontent.com/3612297/123183177-d36e8680-d445-11eb-9bfe-dbb644ca001b.png)
