### PR TITLE
fixing filter selection reset when returning from Place screen

### DIFF
--- a/client/src/containers/Home/ui/CitySelect.js
+++ b/client/src/containers/Home/ui/CitySelect.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
-import { setSelectedCity, requestGetPlaces, requestGetCities, resetRequestStatus, resetFilters } 
+import { setSelectedCity, requestGetPlaces, requestGetCities, resetRequestStatus, resetFilters, setSelectedPlaceType } 
   from 'containers/Home/data/homeSlice'
 import { getCitiesData } from 'containers/Home/data/homeSelectors'
 
@@ -39,6 +39,7 @@ function CitySelect () {
   const handleCitySelection = (id) =>{
     dispatch(resetRequestStatus('filtersRequest'))
     dispatch(resetFilters())
+    dispatch(setSelectedPlaceType('Any'))
     dispatch(setSelectedCity(id))
     setIsSelecting(false)
   }

--- a/client/src/containers/Home/ui/CitySelect.js
+++ b/client/src/containers/Home/ui/CitySelect.js
@@ -32,13 +32,13 @@ function CitySelect () {
   useEffect(() => {
     if (citiesData.selectedCity) {
       dispatch(requestGetPlaces(citiesData.selectedCity.id))
-      dispatch(resetRequestStatus('filtersRequest'))
-      dispatch(resetFilters())
       setSelectedCityImage(citiesData.citiesImages[citiesData.selectedCity.name])
     }
   }, [dispatch, citiesData])
   
   const handleCitySelection = (id) =>{
+    dispatch(resetRequestStatus('filtersRequest'))
+    dispatch(resetFilters())
     dispatch(setSelectedCity(id))
     setIsSelecting(false)
   }


### PR DESCRIPTION
Fixes #31 

## Summary

The reset logic was firing every-time `citiesData` changed, now it fires only when another City is selected, probably the only time you want your filters to be reset outside of a 'clear filters' button which we can add at a later point.

Yep, I literally just moved those two lines of code lol.

## Testing steps
- Checkout `bug-fix-issue-33-filters-reset`
- Select some `Filters` on the `Home` screen
- Click on a `Place` to be taken to the `Place` screen
- Click on the 'Home' button at the top of the `Place` screen
- Confirm that the `Filters` your previously selected are still there