### PR TITLE
close #26 - fixing filter select ui

### DIFF
--- a/client/src/components/Tag/Tag.js
+++ b/client/src/components/Tag/Tag.js
@@ -1,0 +1,11 @@
+const Tag = (props) => {
+  return (
+    <span 
+      onClick={() => props.clickHandler() }
+      className={`tag is-medium ${ props.isSelected ? 'is-primary' : '' }`}>
+      { props.text }
+    </span>
+  )
+}
+
+export default Tag

--- a/client/src/containers/Home/ui/FilterSelect.js
+++ b/client/src/containers/Home/ui/FilterSelect.js
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { requestGetFilters, setSelectedFilter } from 'containers/Home/data/homeSlice'
 import { getFiltersData, getCitiesData } from 'containers/Home/data/homeSelectors'
 
-import Card from 'components/Card/Card'
+import Tag from 'components/Tag/Tag'
 import Notification from 'components/Notification/Notification'
 
 function FilterSelect () {
@@ -43,14 +43,13 @@ function FilterSelect () {
 
           return (
             <div className="column" key={`filter-select-block-${filter.id}`}>
-              <Card
-                cardType='image'
-                imageRatio='is-128x128'
-                image={ filtersData.filtersImages[filter.usp || filter.vital_info] }
-                title={ filter.usp || filter.vital_info }
-                isSelected={ isSelected }
-                clickHandler={() => handleFilterSelection(filter.id)}
-              />
+              <div class="tags">
+                <Tag
+                  clickHandler={ () => handleFilterSelection(filter.id) }
+                  isSelected={ isSelected }
+                  text={ filter.usp || filter.vital_info }
+                />
+              </div>
             </div>
           )
         }))


### PR DESCRIPTION
Closing #26 
## Overview and reasoning

I've decided to just use Tags with the text of the Filter (`vital_info` or `usp`) for the `FilterSelect` UI (see screenshot) instead of icons for now.

It doesn't seem worth it at this point to spend the time choosing and mapping icons for each filter for the MVP, especially when we haven't got the design figured out.

This PR just adds the `Tag` component and uses it in FilterSelect.

You can see from this PR how easy it would be to add icons to the Tags or use something else in the future.

## Testing
- Pull down `26-updating-filter-select`
- `npm run start`
- Select `London` as the city
- Notice the filters showing up as Tags
- Click a few, observe that the Places results are filtered and the Tag element changes color when selected
- Click on a place, and return to the Home screen, observe that the Filter selections remain

![image](https://user-images.githubusercontent.com/3612297/123996300-094ec600-d984-11eb-8241-1d4ce487b1a7.png)
